### PR TITLE
chore: bump node version tag

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -168,9 +168,9 @@ const channel = client.channels.cache.find(channel => channel.name === "general"
 """
 
 [node-version]
-keywords = ["node-version", "flat", "fields flat", "catch {", "update node"]
+keywords = ["node-version", "nv", "flat", "fields flat", "catch {", "update node"]
 content = """
-Please update node.js to version 14.0.0 or newer!
+Please update node.js to version 16.0.0 or newer!
 • [Download](<https://nodejs.org/en/download>)
 • [Linux (nodesource)](<https://github.com/nodesource/distributions>)
 """


### PR DESCRIPTION
This PR bumps the node version in the update tag to 16 and adds an additional alias for improved laziness.