### PR TITLE
fix(tags): escape embedding anchor

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -504,7 +504,7 @@ keywords = ["version", "discord.js version", "provide version", "find version"]
 content = """
 Determining your discord.js version:
 • `npm list discord.js`
-• Make sure you use the right [documentation](https://discord.js.org/#/docs/) for your installed verison (selector on the left)
+• Make sure you use the right [documentation](<https://discord.js.org/#/docs>) for your installed verison (selector on the left)
 """
 
 [token]


### PR DESCRIPTION
anchored links need to be escaped within the `[]` section to not embed in discord