### PR TITLE
feat(tags): validate masked links to be escaped

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -504,7 +504,7 @@ keywords = ["version", "discord.js version", "provide version", "find version"]
 content = """
 Determining your discord.js version:
 • `npm list discord.js`
-• Make sure you use the right [documentation](https://discord.js.org/#/docs/) for your installed verison (selector on the left)
+• Make sure you use the right [documentation](<https://discord.js.org/#/docs>) for your installed verison (selector on the left)
 """
 
 [token]


### PR DESCRIPTION
Discord embeds masked links in the `[label](link)` format. they thus have to be escaped as `[label](<link>)` as mentioned in the README. However, this is an easy-to-miss oversight in PR's. This PR adds validation for links (code blocks are excluded to allow the explanation of the syntax within tags without blocking the validation)