### PR TITLE
Tag: `could-not-connect` and `rpc-buttons`

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -838,8 +838,8 @@ content = """
 Things to consider when getting a connection closed/could not connect error:
 • What transport are you using? If it's `'websocket'`, change that to `'ipc'`.
 • Is the ID you are trying to login with your user ID? If so, you should be using a `Client ID` from the [Developer Portal](<https://discord.com/developers/applications>) instead.
-• Is the ID a string? If not, JavaScript will truncate it's value causing.
-• Are you using the Discord app? It won't be able to connect to the web version. Likewise, bots cannot utilize RPC.
+• Is the ID a string? If not, JavaScript will truncate it's value causing the connection to fail.
+• Are you using the Discord app? It won't be able to connect to the web version. Similarly, bots cannot use RPC.
 • Is your code running on the same machine as the Discord app?
 • Are you trying to run it from WSL? If so, it won't be able to connect either.
 • Have you installed Discord from the snap store? If so, install it from your distro's package repository or directly from the Discord website.
@@ -853,5 +853,5 @@ If you want to add buttons to your rich presence, inside your `setActivity` call
 buttons: [ { label: " ", url: " " }, { label: " ", url: " "} ]
 ```
 You can have up to 2 buttons.
-*You __will not__ be able to press these buttons on your own account, so dont freak out when something doesnt pop up when you click it.*
+*You __will not__ be able to press these buttons on your own account, so dont freak out when something doesn't pop up when you click it.*
 """

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -833,7 +833,7 @@ content = """
 """
 
 [could-not-connect]
-keywords = ["cnc",  "could not connect", "couldn't connect", "cc", "connection closed"]
+keywords = ["could-not-connect", "cnc",  "could not connect", "couldn't connect", "cc", "connection closed"]
 content = """
 Things to consider when getting a connection closed/could not connect error:
 • What transport are you using? If it's `'websocket'`, change that to `'ipc'`.

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -831,3 +831,27 @@ content = """
 • Websocket intents limit events and decrease memory usage: [learn more](<https://discordjs.guide/popular-topics/intents.html>)
 • See what intents you need [here](<https://discord.com/developers/docs/topics/gateway#list-of-intents>)
 """
+
+[could-not-connect]
+keywords = ["cnc",  "could not connect", "couldn't connect", "cc", "connection closed"]
+content = """
+Things to consider when getting a connection closed/could not connect error:
+• What transport are you using? If it's `'websocket'`, change that to `'ipc'`.
+• Is the ID you are trying to login with your user ID? If so, you should be using a `Client ID` from the [Developer Portal](<https://discord.com/developers/applications>) instead.
+• Is the ID a string? If not, JavaScript will truncate it's value causing.
+• Are you using the Discord app? It won't be able to connect to the web version. Likewise, bots cannot utilize RPC.
+• Is your code running on the same machine as the Discord app?
+• Are you trying to run it from WSL? If so, it won't be able to connect either.
+• Have you installed Discord from the snap store? If so, install it from your distro's package repository or directly from the Discord website.
+"""
+
+[rpc-buttons]
+keywords = ["rpc-buttons"]
+content = """
+If you want to add buttons to your rich presence, inside your `setActivity` call, you can use 
+```js
+buttons: [ { label: " ", url: " " }, { label: " ", url: " "} ]
+```
+You can have up to 2 buttons.
+*You __will not__ be able to press these buttons on your own account, so dont freak out when something doesnt pop up when you click it.*
+"""


### PR DESCRIPTION
Both of these tags are former Yuddachi tags that are super handy in the `#rpc` support channel.

---

**Tag:** `could-not-connect`
**Aliases:** `cnc`, `could not connect`, `couldn't connect`, `cc`, `connection closed`
**Content:** 
Things to consider when getting a connection closed/could not connect error:
• What transport are you using? If it's `'websocket'`, change that to `'ipc'`.
• Is the ID you are trying to login with your user ID? If so, you should be using a `Client ID` from the [Developer Portal](<https://discord.com/developers/applications>) instead.
• Is the ID a string? If not, JavaScript will truncate it's value causing the connection to fail.
• Are you using the Discord app? It won't be able to connect to the web version. Similarly, bots cannot use RPC.
• Is your code running on the same machine as the Discord app?
• Are you trying to run it from WSL? If so, it won't be able to connect either.
• Have you installed Discord from the snap store? If so, install it from your distro's package repository or directly from the Discord website.

---

**Tag:** `rpc-buttons`
**Aliases:** none
**Content:**
If you want to add buttons to your rich presence, inside your `setActivity` call, you can use 
```js
buttons: [ { label: " ", url: " " }, { label: " ", url: " "} ]
```
You can have up to 2 buttons.
*You **will not** be able to press these buttons on your own account, so dont freak out when something doesn't pop up when you click it.*