### PR TITLE
chore: Use new url for interactions

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -559,7 +559,7 @@ How we generate our documentation:
 keywords = ["slash-limits", "slash limits", "/limits", "slash command limits"]
 content = """
 Slash command limits:
-• [Discord Developer Documentation](<https://discord.com/developers/docs/interactions/slash-commands>) 
+• [Discord Developer Documentation](<https://discord.com/developers/docs/interactions/application-commands#registering-a-command>) 
 """
 
 [equals]


### PR DESCRIPTION
Updated the link to point to the new area where the limits are documented.