### PR TITLE
fix(sharding): remove recommended text

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -407,7 +407,7 @@ setTimeout(5000).then(() => { ... });
 keywords = ["sharding", "sharding types", "when to shard", "wts"]
 content = """
 • Necessary at 2,500 guilds (discord will not let your bot connect)
-• Internal sharding (recommended):
+• Internal sharding:
 ```js
 const client = new Discord.Client({ shards: 'auto' }); // auto shards
 const client = new Discord.Client({ shards: [0, 1] }); // specific shards


### PR DESCRIPTION
As mentioned in the tip in the guide here <https://discordjs.guide/sharding/#how-does-sharding-work> the tag has been edited to not have "Internal Sharding" as recommended

> Apart from ShardingManager, discord.js also supports a sharding mode known as Internal sharding. Internal sharding creates multiple websocket connections from the same process, and does not require major code changes. To enable it, simply pass `shards: 'auto'` as ClientOptions to the Client constructor. **However, internal sharding is not ideal for bigger bots due to high memory usage of the single main process** and will not be further discussed in this guide.