### PR TITLE
Fixed embed-files tag

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -764,9 +764,9 @@ content = """
 ```diff
   const attachment = new MessageAttachment('./image.png', 'image1.png');
   const embed = new MessageEmbed()
+-   .attachFiles([attachment])
     .setTitle('Attachments')
-    .setImage(`attachment://${attachment.name}`)
--   .attachFiles([attachment]);
+    .setImage(`attachment://${attachment.name}`);
 
 - channel.send(embed)
 + channel.send({

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -762,10 +762,17 @@ keywords = ["embed-files", "embed files"]
 content = """
 `MessageEmbed#attachFiles` has been removed. Files should be attached via the message option object instead:
 ```diff
-- const embed = new MessageEmbed().setTitle('Attachments').attachFiles(['./image1.png', './image2.jpg']);
+  const attachment = new MessageAttachment('./image.png', 'image1.png');
+  const embed = new MessageEmbed()
+    .setTitle('Attachments')
+    .setImage(`attachment://${attachment.name}`)
+-   .attachFiles([attachment]);
+
 - channel.send(embed)
-+ const embed = new MessageEmbed().setTitle('Attachments');
-+ channel.send({ embeds: [embed], files: ['./image1.png', './image2.jpg'] });
++ channel.send({
++   embeds: [embed],
++   files: [attachment]
++ });
 ```
 """
 


### PR DESCRIPTION
Improved diff code-block to more precisely show the changes necessary to replace the old `MessageEmbed#attachFiles` method.