### PR TITLE
fix: update discordjs-docs-parser lib to fix a formatting issue in `/djs`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"algoliasearch": "^4.10.2",
 				"cheerio": "*",
 				"discord-interactions": "^2.3.0",
-				"discordjs-docs-parser": "^1.0.0",
+				"discordjs-docs-parser": "^1.1.0",
 				"dotenv": "^10.0.0",
 				"fastest-levenshtein": "^1.0.12",
 				"html-entities": "^2.3.2",
@@ -613,41 +613,12 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
 			"integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA=="
 		},
-		"node_modules/@sapphire/docusaurus-plugin-npm2yarn2pnpm": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@sapphire/docusaurus-plugin-npm2yarn2pnpm/-/docusaurus-plugin-npm2yarn2pnpm-1.0.0.tgz",
-			"integrity": "sha512-8/S0w2D4gePNuHomfGS7ZF8i2hM95RBoDB/Im3dVIImmYoSIvNndKwiDG29tz6Jtes27mDjxrt5+Pe+fOQU1ZA==",
-			"dependencies": {
-				"@sapphire/prettier-config": "^1.2.4",
-				"esm-to-cjs": "^1.2.0",
-				"npm-to-yarn": "^1.0.1",
-				"prettier": "^2.5.0",
-				"tslib": "^2.3.1",
-				"typescript": "^4.5.2"
-			},
-			"engines": {
-				"node": ">=v16.6.0",
-				"npm": ">=7.0.0"
-			}
-		},
 		"node_modules/@sapphire/fetch": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@sapphire/fetch/-/fetch-2.0.3.tgz",
 			"integrity": "sha512-eqqEv21eeBthgWc0d428syCLh7ReBOO8qwk6CY2bhkP+gNIvzB8W+88ajgu/2KhIjesiaj8cRNK4wGhtolNbKw==",
 			"dependencies": {
 				"cross-fetch": "^3.1.4"
-			},
-			"engines": {
-				"node": ">=v14.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@sapphire/prettier-config": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@sapphire/prettier-config/-/prettier-config-1.2.6.tgz",
-			"integrity": "sha512-1+eRppdbmPWh1SqcHviCfqwQsZa1mxWltn3qfSyvy+TUfyF+0/5PEtNwn9qwh0hdQzz5N/feG45bdrqmbrdMww==",
-			"dependencies": {
-				"prettier": "^2.5.0"
 			},
 			"engines": {
 				"node": ">=v14.0.0",
@@ -1580,15 +1551,13 @@
 			}
 		},
 		"node_modules/discordjs-docs-parser": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discordjs-docs-parser/-/discordjs-docs-parser-1.0.0.tgz",
-			"integrity": "sha512-5McnoXesrBs4FyvQ3tizsEAc99TvWIqjvwYBCs+u/lZ7E5kJFs4zIfLQNztp/+HlkxMFHVYJpDx4bZJvj5NmDw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/discordjs-docs-parser/-/discordjs-docs-parser-1.1.0.tgz",
+			"integrity": "sha512-KlUjor+idLQBLmTNOi+0AU/4eq1FW2OzHFhxXyAbdaN3kKMmAxVg25WcATeABh9NIntl7SK+WACJVc5U9rh54w==",
 			"dependencies": {
-				"@sapphire/docusaurus-plugin-npm2yarn2pnpm": "^1.0.0",
 				"@sapphire/fetch": "^2.0.3",
 				"@sapphire/utilities": "^3.1.0",
-				"@skyra/jaro-winkler": "^1.0.0",
-				"tslib": "^2.3.1"
+				"@skyra/jaro-winkler": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=v16.6.0",
@@ -1910,11 +1879,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/esm-to-cjs": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/esm-to-cjs/-/esm-to-cjs-1.2.0.tgz",
-			"integrity": "sha512-pVKBUyde11DZ9fezHtcvX2Ha1hh48GaoVvTxsDkgukPFQ9fvJL/x1RIINU5qkpdW4evN338Wg97qItq8qedsKw=="
 		},
 		"node_modules/espree": {
 			"version": "7.3.1",
@@ -3117,17 +3081,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm-to-yarn": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/npm-to-yarn/-/npm-to-yarn-1.0.1.tgz",
-			"integrity": "sha512-bp8T8oNMfLW+N/fE0itFfSu7RReytwhqNd9skbkfHfzGYC+5CCdzS2HnaXz6JiG4AlK2eA0qlT6NJN1SoFvcWQ==",
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/nebrelbug/npm-to-yarn?sponsor=1"
-			}
-		},
 		"node_modules/nth-check": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
@@ -3430,6 +3383,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
 			"integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
+			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
@@ -4304,6 +4258,7 @@
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
 			"integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4943,33 +4898,12 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
 			"integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA=="
 		},
-		"@sapphire/docusaurus-plugin-npm2yarn2pnpm": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@sapphire/docusaurus-plugin-npm2yarn2pnpm/-/docusaurus-plugin-npm2yarn2pnpm-1.0.0.tgz",
-			"integrity": "sha512-8/S0w2D4gePNuHomfGS7ZF8i2hM95RBoDB/Im3dVIImmYoSIvNndKwiDG29tz6Jtes27mDjxrt5+Pe+fOQU1ZA==",
-			"requires": {
-				"@sapphire/prettier-config": "^1.2.4",
-				"esm-to-cjs": "^1.2.0",
-				"npm-to-yarn": "^1.0.1",
-				"prettier": "^2.5.0",
-				"tslib": "^2.3.1",
-				"typescript": "^4.5.2"
-			}
-		},
 		"@sapphire/fetch": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@sapphire/fetch/-/fetch-2.0.3.tgz",
 			"integrity": "sha512-eqqEv21eeBthgWc0d428syCLh7ReBOO8qwk6CY2bhkP+gNIvzB8W+88ajgu/2KhIjesiaj8cRNK4wGhtolNbKw==",
 			"requires": {
 				"cross-fetch": "^3.1.4"
-			}
-		},
-		"@sapphire/prettier-config": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@sapphire/prettier-config/-/prettier-config-1.2.6.tgz",
-			"integrity": "sha512-1+eRppdbmPWh1SqcHviCfqwQsZa1mxWltn3qfSyvy+TUfyF+0/5PEtNwn9qwh0hdQzz5N/feG45bdrqmbrdMww==",
-			"requires": {
-				"prettier": "^2.5.0"
 			}
 		},
 		"@sapphire/utilities": {
@@ -5655,15 +5589,13 @@
 			}
 		},
 		"discordjs-docs-parser": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discordjs-docs-parser/-/discordjs-docs-parser-1.0.0.tgz",
-			"integrity": "sha512-5McnoXesrBs4FyvQ3tizsEAc99TvWIqjvwYBCs+u/lZ7E5kJFs4zIfLQNztp/+HlkxMFHVYJpDx4bZJvj5NmDw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/discordjs-docs-parser/-/discordjs-docs-parser-1.1.0.tgz",
+			"integrity": "sha512-KlUjor+idLQBLmTNOi+0AU/4eq1FW2OzHFhxXyAbdaN3kKMmAxVg25WcATeABh9NIntl7SK+WACJVc5U9rh54w==",
 			"requires": {
-				"@sapphire/docusaurus-plugin-npm2yarn2pnpm": "^1.0.0",
 				"@sapphire/fetch": "^2.0.3",
 				"@sapphire/utilities": "^3.1.0",
-				"@skyra/jaro-winkler": "^1.0.0",
-				"tslib": "^2.3.1"
+				"@skyra/jaro-winkler": "^1.0.0"
 			}
 		},
 		"doctrine": {
@@ -5889,11 +5821,6 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
 			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 			"dev": true
-		},
-		"esm-to-cjs": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/esm-to-cjs/-/esm-to-cjs-1.2.0.tgz",
-			"integrity": "sha512-pVKBUyde11DZ9fezHtcvX2Ha1hh48GaoVvTxsDkgukPFQ9fvJL/x1RIINU5qkpdW4evN338Wg97qItq8qedsKw=="
 		},
 		"espree": {
 			"version": "7.3.1",
@@ -6800,11 +6727,6 @@
 				"path-key": "^3.0.0"
 			}
 		},
-		"npm-to-yarn": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/npm-to-yarn/-/npm-to-yarn-1.0.1.tgz",
-			"integrity": "sha512-bp8T8oNMfLW+N/fE0itFfSu7RReytwhqNd9skbkfHfzGYC+5CCdzS2HnaXz6JiG4AlK2eA0qlT6NJN1SoFvcWQ=="
-		},
 		"nth-check": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
@@ -7021,7 +6943,8 @@
 		"prettier": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
-			"integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg=="
+			"integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
+			"dev": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -7669,7 +7592,8 @@
 		"typescript": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-			"integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw=="
+			"integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+			"dev": true
 		},
 		"universalify": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"algoliasearch": "^4.10.2",
 		"cheerio": "*",
 		"discord-interactions": "^2.3.0",
-		"discordjs-docs-parser": "^1.0.0",
+		"discordjs-docs-parser": "^1.1.0",
 		"dotenv": "^10.0.0",
 		"fastest-levenshtein": "^1.0.12",
 		"html-entities": "^2.3.2",


### PR DESCRIPTION
This will fix the issue of embedded links not being markdown escaped as
found by Souji when testing, specifically when searching `TimestampStylesString`
which would embed a link to discord.com.