### PR TITLE
chore: bump LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2021 almostSouji
+   Copyright 2022 almostSouji
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Another year, another bump. Bumps the license year to 2022!
