### PR TITLE
chore: remove `implements` as `interface`(s) are not shown in documentation

### DIFF
--- a/src/functions/docs.ts
+++ b/src/functions/docs.ts
@@ -54,7 +54,6 @@ export function resolveElementString(element: DocElement, doc: Doc): string {
 	if (element.static) parts.push(`${bold('(static)')} `);
 	parts.push(underscore(bold(escapeMDLinks(element.link ?? ''))));
 	if (element.extends) parts.push(formatInheritance('extends', element.extends, doc));
-	if (element.implements) parts.push(formatInheritance('implements', element.implements, doc));
 	if (element.access === 'private') parts.push(` ${bold('PRIVATE')}`);
 	if (element.deprecated) parts.push(` ${bold('DEPRECATED')}`);
 


### PR DESCRIPTION
Closes #48 

An alternative option would be to specifically check for interfaces and not hyperlink them but they aren't really shown in documentation so I'm unsure if that would have much point