### PR TITLE
Tag: number-id

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -920,3 +920,13 @@ You have alredy replied to the interaction.
 • Responding to buttons: [learn more](<https://discordjs.guide/interactions/buttons.html#responding-to-buttons>)
 • Responding to select menus: [learn more](<https://discordjs.guide/interactions/select-menus.html#responding-to-select-menus>)
 """
+
+[number-id]
+keywords = ["number-id", "integer-overflow", "id", "snowflake"]
+content = """
+Discord IDs are too high for numbers in JavaScript, so they must be represented as strings
+```diff
+- client.guilds.cache.get(123456789012345678)
++ client.guilds.cache.get("123456789012345678")
+```
+"""

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -235,7 +235,12 @@ The "canary" client is Discord's public test build
 [snowflake]
 keywords = ["snowflake", "❄", "discord snowflake", "discord id", "snowflakes"]
 content = """
-Discord ids follow the snowflake format: [learn more](<https://discord.com/developers/docs/reference#snowflakes>)
+• Discord IDs follow the snowflake format: [learn more](<https://discord.com/developers/docs/reference#snowflakes>)
+• Discord IDs are too high to be represented as numbers in JavaScript, so they must be represented as strings
+```diff
+- client.guilds.cache.get(123456789012345678)
++ client.guilds.cache.get("123456789012345678")
+```
 """
 
 [typescript]
@@ -919,14 +924,4 @@ You have alredy replied to the interaction.
 • Replying to slash commands: [learn more](<https://discordjs.guide/interactions/slash-commands.html#replying-to-slash-commands>)
 • Responding to buttons: [learn more](<https://discordjs.guide/interactions/buttons.html#responding-to-buttons>)
 • Responding to select menus: [learn more](<https://discordjs.guide/interactions/select-menus.html#responding-to-select-menus>)
-"""
-
-[number-id]
-keywords = ["number-id", "integer-overflow", "id", "snowflake"]
-content = """
-Discord IDs are too high to be represented as numbers in JavaScript, so they must be represented as strings
-```diff
-- client.guilds.cache.get(123456789012345678)
-+ client.guilds.cache.get("123456789012345678")
-```
 """

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -235,8 +235,8 @@ The "canary" client is Discord's public test build
 [snowflake]
 keywords = ["snowflake", "❄", "discord snowflake", "discord id", "snowflakes"]
 content = """
-• Discord IDs follow the snowflake format: [learn more](<https://discord.com/developers/docs/reference#snowflakes>)
-• Discord IDs are too high to be represented as numbers in JavaScript, so they must be represented as strings
+• Discord ids follow the snowflake format: [learn more](<https://discord.com/developers/docs/reference#snowflakes>)
+• Discord ids are larger than `Number.MAX_SAFE_INTEGER`, the largest number that can represented in JavaScript, so they must be represented as strings
 ```diff
 - client.guilds.cache.get(123456789012345678)
 + client.guilds.cache.get("123456789012345678")

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -236,7 +236,7 @@ The "canary" client is Discord's public test build
 keywords = ["snowflake", "❄", "discord snowflake", "discord id", "snowflakes"]
 content = """
 • Discord ids follow the snowflake format: [learn more](<https://discord.com/developers/docs/reference#snowflakes>)
-• Discord ids must be represented as strings as they are larger than `Number.MAX_SAFE_INTEGER`, the largest number that can represented in JavaScript
+• Discord ids must be represented as strings as they are larger than `Number.MAX_SAFE_INTEGER`, the largest number that can be represented in JavaScript
 ```diff
 - client.guilds.cache.get(123456789012345678)
 + client.guilds.cache.get("123456789012345678")

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -236,7 +236,7 @@ The "canary" client is Discord's public test build
 keywords = ["snowflake", "❄", "discord snowflake", "discord id", "snowflakes"]
 content = """
 • Discord ids follow the snowflake format: [learn more](<https://discord.com/developers/docs/reference#snowflakes>)
-• Discord ids must be represented as strings as they are larger than `Number.MAX_SAFE_INTEGER`, the largest number that can be represented in JavaScript
+• Discord ids must be represented as strings as they are larger than `Number.MAX_SAFE_INTEGER`, the largest integer that can be represented in JavaScript
 ```diff
 - client.guilds.cache.get(123456789012345678)
 + client.guilds.cache.get("123456789012345678")

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -236,7 +236,7 @@ The "canary" client is Discord's public test build
 keywords = ["snowflake", "❄", "discord snowflake", "discord id", "snowflakes"]
 content = """
 • Discord ids follow the snowflake format: [learn more](<https://discord.com/developers/docs/reference#snowflakes>)
-• Discord ids are larger than `Number.MAX_SAFE_INTEGER`, the largest number that can represented in JavaScript, so they must be represented as strings
+• Discord ids must be represented as strings as they are larger than `Number.MAX_SAFE_INTEGER`, the largest number that can represented in JavaScript
 ```diff
 - client.guilds.cache.get(123456789012345678)
 + client.guilds.cache.get("123456789012345678")

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -924,7 +924,7 @@ You have alredy replied to the interaction.
 [number-id]
 keywords = ["number-id", "integer-overflow", "id", "snowflake"]
 content = """
-Discord IDs are too high for numbers in JavaScript, so they must be represented as strings
+Discord IDs are too high to be represented as numbers in JavaScript, so they must be represented as strings
 ```diff
 - client.guilds.cache.get(123456789012345678)
 + client.guilds.cache.get("123456789012345678")


### PR DESCRIPTION
A tag showing that Discord IDs must be represented as strings