### PR TITLE
fix: decode HTML entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"discord-api-types": "^0.30.0-next.f702988.1648076699",
 		"discordjs-docs-parser": "^1.3.0",
 		"dotenv": "^10.0.0",
+		"he": "^1.2.0",
 		"html-entities": "^2.3.2",
 		"kleur": "^4.1.4",
 		"pino": "^6.11.3",
@@ -45,6 +46,7 @@
 	"devDependencies": {
 		"@commitlint/cli": "^12.1.4",
 		"@commitlint/config-angular": "^12.1.4",
+		"@types/he": "^1.1.2",
 		"@types/node": "17",
 		"@types/pino": "^6.3.8",
 		"@types/turndown": "^5.0.1",

--- a/src/functions/algoliaResponse.ts
+++ b/src/functions/algoliaResponse.ts
@@ -4,6 +4,7 @@ import { Response } from 'polka';
 import { AlgoliaHit } from '../types/algolia';
 import { API_BASE_ALGOLIA, prepareErrorResponse, prepareResponse, truncate } from '../util';
 import { resolveHitToNamestring } from './autocomplete/algoliaAutoComplete';
+import { decode } from 'he';
 
 export async function algoliaResponse(
 	res: Response,
@@ -32,7 +33,7 @@ export async function algoliaResponse(
 			res,
 			`${target ? `${italic(`Suggestion for ${userMention(target)}:`)}\n` : ''}<:${emojiName}:${emojiId}>  ${bold(
 				resolveHitToNamestring(hit),
-			)}${hit.content?.length ? `\n${truncate(hit.content, 300)}` : ''}\n${hyperlink(
+			)}${hit.content?.length ? `\n${truncate(decode(hit.content), 300)}` : ''}\n${hyperlink(
 				'read more',
 				hideLinkEmbed(hit.url),
 			)}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,6 +431,11 @@
     "@toml-tools/lexer" "^0.3.1"
     chevrotain "4.1.1"
 
+"@types/he@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/he/-/he-1.1.2.tgz#0c8b275f36d2b8b651104638e4d45693349c3953"
+  integrity sha512-kSJPcLO1x+oolc0R89pUl2kozldQ/fVQ1C1p5mp8fPoLdF/ZcBvckaTC2M8xXh3GYendXvCpy5m/a2eSbfgNgw==
+
 "@types/json-schema@^7.0.7":
   version "7.0.10"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.10.tgz#9b05b7896166cd00e9cbd59864853abf65d9ac23"
@@ -1416,6 +1421,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"


### PR DESCRIPTION
This will ensure that entities such as `&#x27;` get properly decoded to `'`. Noticed it here: https://discord.com/channels/222078108977594368/222197033908436994/995710742277935204

(Added package is from https://github.com/mathiasbynens. Wouldn't normally just add a dependency for this but Mathias is an exception as a dev IMHO)

![image](https://user-images.githubusercontent.com/4019718/178151375-dffc0dbc-d26f-4d47-9394-aa8be6e6498b.png)
