### PR TITLE
chore: Update tags

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -507,7 +507,7 @@ https://discord.com/oauth2/authorize?client_id=CLIENT_ID&scope=bot&permissions=0
 ```
 • `CLIENT_ID` needs to be replaced with your bot id
 • Permission calculator: [learn more](<https://finitereality.github.io/permissions-calculator>)
-• If you need slash commands and the bot scope you can use `scope=bot applications.commands`
+• `bot` scope includes `applications.commands`. If you don't need the bot, use `applications.commands` instead
 • You can use #generateInvite instead: [learn more](<https://discord.js.org/#/docs/discord.js/stable/class/Client?scrollTo=generateInvite>)
 """
 
@@ -980,8 +980,8 @@ To receive direct message events on `"messageCreate"` with your bot, you will ne
 keywords = ["all-intents", "98303", "32767", "magic-intents", "magic intents", "magic all intent", "all intents"]
 content = """
 We highly recommend only specifying the [intents](<https://discordjs.guide/popular-topics/intents>) you actually need.
-• Note, that `98303`, `32767` or whatever other magic number you read represents "all intents", somewhere, gets outdated as soon as new intents are introduced.
-• The number will always represent the same set of intents, excluding new ones, there is no magic "all intents" bit.
+• Note, that `98303`, `32767` or whatever other magic number you read that represents "all intents", gets outdated as soon as new intents are introduced.
+• The number will always represent the same set of intents, and will not include new intents. There is no magic "all intents" bit.
 """
 
 [manager-functions]

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -981,7 +981,7 @@ keywords = ["all-intents", "98303", "32767", "magic-intents", "magic intents", "
 content = """
 We highly recommend only specifying the [intents](<https://discordjs.guide/popular-topics/intents>) you actually need.
 • Note, that `98303`, `32767` or whatever other magic number you read that represents "all intents", gets outdated as soon as new intents are introduced.
-• The number will always represent the same set of intents, and will not include new intents. There is no magic "all intents" bit.
+• The number will always represent the same set of intents, and will not include new ones. There is no magic "all intents" bit.
 """
 
 [manager-functions]


### PR DESCRIPTION
Updated `bot-invite` tag to reflect the (not so) recent change, where the 2 options are essentially either `bot` scope or `application.commands`, and they both result in having `application.commands` anyway. [Our news msg link](https://canary.discord.com/channels/222078108977594368/992166350640386090/996100739510304809).

Updated `all-intents` tag to have actually comprehensible first bullet point, and reworded the second point so that it reads more as "new stuff gets added but the number stays the same" and not "discord removed an intent from this number". Plus that comma there was weird anyway.
