### PR TITLE
chore: add more aliases to the `masked-links` tag

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -358,7 +358,7 @@ Oauth is about giving access to your stuff without sharing your identity
 """
 
 [masked-links]
-keywords = ["masked-links", "embed-links", "embedlinks", "inline-links"]
+keywords = ["masked-links", "embed-links", "embedlinks", "inline-links", "hyperlinks", "hyperlink", "hyper-links", "hyper-link"]
 content = """
 You can use markdown syntax to display clickable links in embeds, webhook messages and interaction responses without showing the url:
 ```markdown


### PR DESCRIPTION
I think the first word that comes in mind is "hyperlinks" rather than "masked-links".