### PR TITLE
fix: Wording and typos

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -11,6 +11,6 @@
 
 # Privacy Policy
 
-This is a HTTP interaction command-only Discord application and does not read any message you send, unless you provide it as an argument to one of its commands. Adding the `bot` scope to your sever does not yield any benefit. This application does not have a websocket connection and does not read any events.
+This is a HTTP interaction command-only Discord application and does not read any message you send, unless you provide it as an argument to one of its commands. Adding the `bot` scope to your server does not yield any benefit. This application does not have a WebSocket connection and does not read any events.
 
-If you contribute tags via the GitHub repository you agree that the provided content is persisted and shown to users on any Discord server with no attribution save the GitHub repository and git history.
+If you contribute tags via the GitHub repository, you agree that the provided content is persisted and shown to users on any Discord server with no attribution save the GitHub repository and git history.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "slash-utils",
 	"version": "0.0.0",
-	"description": "Slash command utilities for the discord.js support server",
+	"description": "Slash command utilities for the discord.js support server.",
 	"scripts": {
 		"build": "rimraf dist && tsc --skipLibCheck",
 		"start": "node dist/index.js",

--- a/src/interactions/discorddocs.ts
+++ b/src/interactions/discorddocs.ts
@@ -2,7 +2,7 @@ import { ApplicationCommandOptionType } from 'discord-api-types/v10';
 
 export const DiscordDocsCommand = {
 	name: 'discorddocs',
-	description: 'Search discord developer documentation',
+	description: 'Search Discord developer documentation',
 	options: [
 		{
 			type: ApplicationCommandOptionType.String,

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -144,7 +144,7 @@ To make your code more readable (and easier for us to help you with) consider us
 [docs]
 keywords = ["docs", "djsdocs", "thedocs", "documentation"]
 content = """
-Discord.js documentation:
+discord.js documentation:
 • stable release: [learn more](<https://discord.js.org/#/docs/discord.js/stable/general/welcome>)
 • developer release: [learn more](<https://discord.js.org/#/docs/discord.js/main/general/welcome>)
 """
@@ -171,7 +171,7 @@ const channel = guild.channels.cache.find(channel => channel.name === "general")
 [node-version]
 keywords = ["node-version", "nv", "flat", "fields-flat", "catch-{", "update-node", "abortcontroller"]
 content = """
-Please update node.js to version 16.9.0 or newer!
+Please update Node.js to version 16.9.0 or newer!
 • [Download](<https://nodejs.org/en/download>)
 • [Linux (nodesource)](<https://github.com/nodesource/distributions>)
 """
@@ -302,7 +302,7 @@ Explaining `<Class>` and `Class#method` notation: [learn more](<https://discordj
 [collection]
 keywords = ["collection", "collections", "collection-methods"]
 content = """
-Discord.js uses [Collection](<https://discord.js.org/#/docs/collection/stable/class/Collection>), an extension of the JS native [Map](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map>) structure.
+discord.js uses [Collection](<https://discord.js.org/#/docs/collection/stable/class/Collection>), an extension of the JS native [Map](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map>) structure.
 • Guide: [learn more](<https://discordjs.guide/additional-info/collections.html>) [🍪](<https://gist.github.com/almostSouji/71a33e5f8e84a0960b4ed3a1609915f5>)
 """
 hoisted = true
@@ -310,7 +310,7 @@ hoisted = true
 [ffmpeg]
 keywords = ["ffmpeg"]
 content = """
-• NPM: `npm install ffmpeg-static`
+• npm: `npm install ffmpeg-static`
 • Install: [Download](<https://www.ffmpeg.org>) | [chocolatey](<https://chocolatey.org>) | [homebrew](<https://brew.sh>) | your distributions package manager
 • Tutorial: [YouTube](<https://www.youtube.com/watch?v=SW-iKrT_nJs>)
 • ffmpeg-binaries is [deprecated](<https://www.npmjs.com/package/ffmpeg-binaries>), uninstall it with `npm rm ffmpeg-binaries`
@@ -998,7 +998,7 @@ Instead of using method-based type guard functions, you can narrow channel types
 [member-fetch-timeout]
 keywords = ["member-fetch-timeout", "member-timeout", "member-fetch-timeout"]
 content = """
-Fetching members can time out on large guilds, as they arrive in chunks through the websocket connections.
+Fetching members can time out on large guilds, as they arrive in chunks through the WebSocket connections.
 • You can specify the `time` option in `FetchMembersOptions` to specify how long you want to wait.
 • Make sure you have the required `GuildMembers` [gateway intent](<https://discordjs.guide/popular-topics/intents>) enabled
 """
@@ -1031,4 +1031,3 @@ const row = new ActionRowBuilder<SelectMenuBuilder>().addComponents(selectMenu)
 const row = new ActionRowBuilder<TextInputBuilder>().addComponents(textInput)
 ```
 """
-


### PR DESCRIPTION
- discord.js capitalisation
- Discord capitalisation
- WebSocket capitalisation
- Node.js capitalisation
- npm capitalisation
- "sever" typo in the privacy policy
- Other miscellaneous changes