### PR TITLE
chore: Typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # build flow
 dist/
 node_modules/
+
+# miscellaneous
+.DS_Store

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -24,7 +24,6 @@ export const API_BASE_MDN = 'https://developer.mozilla.org' as const;
 export const API_BASE_NODE = 'https://nodejs.org' as const;
 export const API_BASE_ALGOLIA = 'algolia.net' as const;
 export const API_BASE_DISCORD = 'https://discord.com/api/v9' as const;
-export const API_BASE_DISCORD_APLICATIONS = `${API_BASE_DISCORD}/applications` as const;
 export const AUTOCOMPLETE_MAX_ITEMS = 20;
 export const MAX_MESSAGE_LENGTH = 4096;
 export const REMOTE_TAG_URL =

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -424,7 +424,7 @@ const client = new Discord.Client({ shards: [0, 1] }); // specific shards
 """
 
 [2fa]
-keywords = ["2fa", "2-factor-auth", "two-factor-auth", "2-factor-authentification"]
+keywords = ["2fa", "2-factor-auth", "two-factor-auth", "2-factor-authentication"]
 content = """
 `DiscordAPIError: Two factor is required for this operation`
 Elevated permissions are required to execute this action. You need to activate 2FA on your developer account in order to do this with the bot.


### PR DESCRIPTION
- `API_BASE_DISCORD_APLICATIONS` had a typo, but this constant was not used. It was therefore removed.
- "authentification" is not a word (this is a common misconception).

Also added .DS_Store to .gitignore.