### PR TITLE
chore: remove rpc subcommand

### DIFF
--- a/src/functions/autocomplete/docsAutoComplete.ts
+++ b/src/functions/autocomplete/docsAutoComplete.ts
@@ -21,7 +21,6 @@ export function toSourceString(s: string): SourcesStringUnion {
 		case 'collection':
 		case 'voice':
 		case 'builders':
-		case 'rpc':
 			return s;
 	}
 

--- a/src/interactions/docs.ts
+++ b/src/interactions/docs.ts
@@ -108,25 +108,5 @@ export const DocsCommand = {
 				},
 			],
 		},
-		{
-			type: ApplicationCommandOptionType.Subcommand,
-			name: 'rpc',
-			description: `${SUBCOMMAND_DESCRIPTION_PREFIX} discord-rpc`,
-			options: [
-				{
-					type: ApplicationCommandOptionType.String,
-					name: 'query',
-					description: QUERY_DESCRIPTION,
-					required: true,
-					autocomplete: true,
-				},
-				{
-					type: ApplicationCommandOptionType.User,
-					name: 'target',
-					description: TARGET_DESCRIPTION,
-					required: false,
-				},
-			],
-		},
 	],
 } as const;


### PR DESCRIPTION
This PR removes the `rpc` subcommand from `/docs`, since there are no longer docs for `rpc`