### PR TITLE
chore: rename 'stable' -> 'main'

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -144,7 +144,7 @@ To make your code more readable (and easier for us to help you with) consider us
 keywords = ["docs", "djsdocs", "thedocs", "documentation"]
 content = """
 discord.js documentation:
-• stable release: [learn more](<https://discord.js.org/#/docs/discord.js/stable/general/welcome>)
+• stable release: [learn more](<https://discord.js.org/#/docs/discord.js/main/general/welcome>)
 • developer release: [learn more](<https://discord.js.org/#/docs/discord.js/main/general/welcome>)
 """
 
@@ -268,9 +268,9 @@ content = """
 keywords = ["allowed-mentions", "enable-mentions", "disable-mentions", "allow-mentions"]
 content = """
 You can control which entities receive notifications via the `allowedMentions` option. You can:
-• Set a [default on the client](<https://discord.js.org/#/docs/discord.js/stable/typedef/ClientOptions>)
-• Set for a [specific message](<https://discord.js.org/#/docs/discord.js/stable/typedef/MessageMentionOptions>)
-• Use the `repliedUser` key to disable [in-line reply mentions](<https://discord.js.org/#/docs/discord.js/stable/typedef/MessageMentionOptions>)
+• Set a [default on the client](<https://discord.js.org/#/docs/discord.js/main/typedef/ClientOptions>)
+• Set for a [specific message](<https://discord.js.org/#/docs/discord.js/main/typedef/MessageMentionOptions>)
+• Use the `repliedUser` key to disable [in-line reply mentions](<https://discord.js.org/#/docs/discord.js/main/typedef/MessageMentionOptions>)
 ```js
 { ..., allowedMentions: { parse: ["users", "roles"] } }
 ```
@@ -301,7 +301,7 @@ Explaining `<Class>` and `Class#method` notation: [learn more](<https://discordj
 [collection]
 keywords = ["collection", "collections", "collection-methods"]
 content = """
-discord.js uses [Collection](<https://discord.js.org/#/docs/collection/stable/class/Collection>), an extension of the JS native [Map](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map>) structure.
+discord.js uses [Collection](<https://discord.js.org/#/docs/collection/main/class/Collection>), an extension of the JS native [Map](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map>) structure.
 • Guide: [learn more](<https://discordjs.guide/additional-info/collections.html>) [🍪](<https://gist.github.com/almostSouji/71a33e5f8e84a0960b4ed3a1609915f5>)
 """
 hoisted = true
@@ -420,7 +420,7 @@ content = """
 const client = new Discord.Client({ shards: 'auto' }); // auto shards
 const client = new Discord.Client({ shards: [0, 1] }); // specific shards
 ```
-• Sharding manager: [learn more](<https://discord.js.org/#/docs/discord.js/stable/class/ShardingManager>)
+• Sharding manager: [learn more](<https://discord.js.org/#/docs/discord.js/main/class/ShardingManager>)
 """
 
 [2fa]
@@ -508,7 +508,7 @@ https://discord.com/oauth2/authorize?client_id=CLIENT_ID&scope=bot&permissions=0
 • `CLIENT_ID` needs to be replaced with your bot id
 • Permission calculator: [learn more](<https://finitereality.github.io/permissions-calculator>)
 • `bot` scope includes `applications.commands`. If you don't need the bot, use `applications.commands` instead
-• You can use #generateInvite instead: [learn more](<https://discord.js.org/#/docs/discord.js/stable/class/Client?scrollTo=generateInvite>)
+• You can use #generateInvite instead: [learn more](<https://discord.js.org/#/docs/discord.js/main/class/Client?scrollTo=generateInvite>)
 """
 
 [version]
@@ -622,9 +622,9 @@ Checking for things to not be equal in JavaScript:
 keywords = ["member-user", "memberuser", "user-member", "usermember"]
 content = """
 Despite sounding similar there is a distinct difference between users and members in Discord:
-• [User](<https://discord.js.org/#/docs/discord.js/stable/class/User>): global Discord user data (global avatar, username, tag, id) 
-• [GuildMember](<https://discord.js.org/#/docs/discord.js/stable/class/GuildMember>): user data associated to a guild (guild, nickname, roles, voice, guild avatar, etc.)
-• Conversion: [User ➞ GuildMember](<https://discord.js.org/#/docs/discord.js/stable/class/GuildMemberManager?scrollTo=fetch>) | [GuildMember ➞ User](<https://discord.js.org/#/docs/discord.js/stable/class/GuildMember?scrollTo=user>)
+• [User](<https://discord.js.org/#/docs/discord.js/main/class/User>): global Discord user data (global avatar, username, tag, id) 
+• [GuildMember](<https://discord.js.org/#/docs/discord.js/main/class/GuildMember>): user data associated to a guild (guild, nickname, roles, voice, guild avatar, etc.)
+• Conversion: [User ➞ GuildMember](<https://discord.js.org/#/docs/discord.js/main/class/GuildMemberManager?scrollTo=fetch>) | [GuildMember ➞ User](<https://discord.js.org/#/docs/discord.js/main/class/GuildMember?scrollTo=user>)
 """
 
 [linter]
@@ -659,7 +659,7 @@ Buttons and Modals are supported natively.
 [find-id]
 keywords = ["find-id", "find-by-id", "id-find", "fbi"]
 content = """
-Don't use the find method to query a [Collection](<https://discord.js.org/#/docs/collection/stable/class/Collection>) by key (mostly the associated id)
+Don't use the find method to query a [Collection](<https://discord.js.org/#/docs/collection/main/class/Collection>) by key (mostly the associated id)
 ```diff
 - someCollection.find(structure => structure.id === "348607796335607817")
 + someCollection.get("348607796335607817")
@@ -703,7 +703,7 @@ hoisted = true
 keywords = ["install", "discord.js-stable", "install-stable", "djs-stable", "install-djs"]
 content = """
 To install run: `npm install discord.js`
-• Documentation: [learn more](<https://discord.js.org/#/docs/discord.js/stable/general/welcome>)
+• Documentation: [learn more](<https://discord.js.org/#/docs/discord.js/main/general/welcome>)
 • Guide: [learn more](<https://discordjs.guide>)
 """
 hoisted = true
@@ -717,15 +717,15 @@ https://i.imgur.com/7WdehGn.png
 [tag-username]
 keywords = ["tag-username", "tagusername", "tag-username-difference"]
 content = """
-[user.username](<https://discord.js.org/#/docs/discord.js/stable/class/User?scrollTo=username>) ➞ `d.js docs`
-[user.discriminator](<https://discord.js.org/#/docs/discord.js/stable/class/User?scrollTo=discriminator>) ➞ `1083`
-[user.tag](<https://discord.js.org/#/docs/discord.js/stable/class/User?scrollTo=tag>) ➞ `d.js docs#1083`
+[user.username](<https://discord.js.org/#/docs/discord.js/main/class/User?scrollTo=username>) ➞ `d.js docs`
+[user.discriminator](<https://discord.js.org/#/docs/discord.js/main/class/User?scrollTo=discriminator>) ➞ `1083`
+[user.tag](<https://discord.js.org/#/docs/discord.js/main/class/User?scrollTo=tag>) ➞ `d.js docs#1083`
 """
 
 [boost-event]
 keywords = ["boost-event", "boost", "boostevent"]
 content = """
-The Discord API does not provide a dedicated event for guild boosts, but you can check for it in the [guildMemberUpdate](<https://discord.js.org/#/docs/discord.js/stable/class/Client?scrollTo=e-guildMemberUpdate>) event:
+The Discord API does not provide a dedicated event for guild boosts, but you can check for it in the [guildMemberUpdate](<https://discord.js.org/#/docs/discord.js/main/class/Client?scrollTo=e-guildMemberUpdate>) event:
 ```js
 client.on("guildMemberUpdate", (oldMember, newMember) => {
     // Check if the member wasn't boosting before, but is now.
@@ -768,7 +768,7 @@ content = """
 [delete-timeout]
 keywords = ["delete-timeout", "deletetimeout", "delete", "message#delete"]
 content = """
-The timeout option has been removed from the [Message#delete](<https://discord.js.org/#/docs/discord.js/stable/class/Message?scrollTo=delete>) method.
+The timeout option has been removed from the [Message#delete](<https://discord.js.org/#/docs/discord.js/main/class/Message?scrollTo=delete>) method.
 ```diff
 - message.delete(5000)
 - message.delete({ timeout: 5000 })
@@ -807,9 +807,9 @@ Ratelimits are dynamically assigned by the API based on current load and may cha
 keywords = ["abort", "abort-error"]
 content = """
 `AbortError: The user aborted a request.`
-A request took longer than the specified [restRequestTimeout](<https://discord.js.org/#/docs/discord.js/stable/typedef/ClientOptions>) (15 seconds default), and was aborted to not lock up the request handler.
+A request took longer than the specified [restRequestTimeout](<https://discord.js.org/#/docs/discord.js/main/typedef/ClientOptions>) (15 seconds default), and was aborted to not lock up the request handler.
 • This can be caused by an internal server error on Discord's side, or just a slow connection.
-• In case of a slow connection, the `restRequestTimeout` option in [ClientOptions](<https://discord.js.org/#/docs/discord.js/stable/typedef/ClientOptions>) can be increased to prevent future AbortErrors.
+• In case of a slow connection, the `restRequestTimeout` option in [ClientOptions](<https://discord.js.org/#/docs/discord.js/main/typedef/ClientOptions>) can be increased to prevent future AbortErrors.
 """
 
 [v14-changes]
@@ -866,7 +866,7 @@ content = """
 **Converting a Collection to an array**
 You only need to convert it to an array if you need the index of an entry:
 • Iteration (looping) is possible with [`for...of`](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#iterating_over_a_map>) over [`Collection#values`](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values>) or [`forEach`](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach>)
-• You can transform a Collection to an array with [`Collection#map`](<https://discord.js.org/#/docs/collection/stable/class/Collection?scrollTo=map>)
+• You can transform a Collection to an array with [`Collection#map`](<https://discord.js.org/#/docs/collection/main/class/Collection?scrollTo=map>)
 • If you need indices, you can get the array using [`[...collection.values()]`](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values>)
 """
 
@@ -875,7 +875,7 @@ keywords = ["member-count", "user-count", "uc"]
 content = """
 **Getting your bot's member count**
 • `client.users.cache.size` is unreliable because it will only return *cached* users
-• The preferred method is using [`collection.reduce()`](<https://discord.js.org/#/docs/collection/stable/class/Collection?scrollTo=reduce>) on `client.guilds.cache`
+• The preferred method is using [`collection.reduce()`](<https://discord.js.org/#/docs/collection/main/class/Collection?scrollTo=reduce>) on `client.guilds.cache`
 ```js
 client.guilds.cache.reduce((acc, guild) => acc + guild.memberCount, 0)
 ```

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -144,7 +144,7 @@ To make your code more readable (and easier for us to help you with) consider us
 keywords = ["docs", "djsdocs", "thedocs", "documentation"]
 content = """
 discord.js documentation:
-• stable release: [learn more](<https://discord.js.org/#/docs/discord.js/main/general/welcome>)
+• stable release: [learn more](<https://discord.js.org/#/docs/discord.js/stable/general/welcome>)
 • developer release: [learn more](<https://discord.js.org/#/docs/discord.js/main/general/welcome>)
 """
 


### PR DESCRIPTION
- Changes tags with `docs/discord.js/stable` to `docs/discord.js/main`