### PR TITLE
Tag: not-djs

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1142,3 +1142,13 @@ Responding to interactions:
 
 *The initial response has to happen within 3s of receiving the interaction!*
 """
+
+[not-djs]
+keywords = ["not-djs", "unrelated", "javascript"]
+content = """
+This support channel is only for djs-related questions:
+• Check out <#237743386864517122> for general-coding and discord api related servers
+• See <#729580210634358804> for links to better understand JavaScript and other useful resources
+• Select 'Other JS questions' in <id:customize> and gain access to <#1081585952654360687> to ask js related questions
+"""
+

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1149,6 +1149,6 @@ content = """
 This support channel is only for djs-related questions:
 • Check out <#237743386864517122> for general-coding and discord api related servers
 • See <#729580210634358804> for links to better understand JavaScript and other useful resources
-• Select 'Other JS questions' in <id:customize> and gain access to <#1081585952654360687> to ask js related questions
+• Select 'Other JS questions' in <id:customize> and gain access to <#1081585952654360687> where you can ask js related questions
 """
 


### PR DESCRIPTION
Tag mainly explains how to get access to the 'other-js-ts' channel, and that their question was not djs related. Although this tag might need some grammar changes. For reference: 'not djs' has been said 17k times in #djs-help-v14

Tag (with resolved channels):
```
This support channel is only for djs-related questions:
• Check out #useful-servers for general-coding and discord api related servers
• See #resources for links to better understand JavaScript and other useful resources
• Select 'Other JS questions' in #Customise Community and gain access to #other-js-ts to ask js related questions
```

*Related to the '[how to get access to the other-js-ts channel](https://discord.com/channels/222078108977594368/1081936575786655744)' thread.*