### PR TITLE
Tag: shared hosting

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1146,5 +1146,5 @@ Responding to interactions:
 [shared-hosting]
 keywords = ["shared-hosting", "replit"]
 content = """
-Replit and many other shared hosting services are highly discouraged; using such hosts means you will share the same IP with many other projects that send a large number of API requests. That means your bot is very likely to have its IP address banned and/or rate limited. [Learn more](https://en.wikipedia.org/wiki/Shared_web_hosting_service)
+Replit and many other shared hosting services are highly discouraged; using such hosts means you will share the same IP with many other projects that send a large number of API requests. That means your bot is very likely to have its IP address banned and/or rate limited. [Learn more](<https://en.wikipedia.org/wiki/Shared_web_hosting_service> "Wikipedia: Shared web hosting service")
 """

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1146,5 +1146,5 @@ Responding to interactions:
 [shared-hosting]
 keywords = ["shared-hosting", "replit"]
 content = """
-Replit and many other shared hosting services are highly discouraged; using such hosts means you will share the same IP with many other projects that send a large number of API requests. That means your bot is very likely to have its IP address banned and/or rate limited. [Learn more](<https://en.wikipedia.org/wiki/Shared_web_hosting_service> "Wikipedia: Shared web hosting service")
+Replit and many other shared hosting services are highly discouraged; using such hosts means you will share the same IP with many other projects that send a large number of API requests. That means your bot is very likely to have its IP address banned and/or rate limited. To avoid this you should use a hosting provider that is not shared, check out <#729580210634358804> for affordable options. [Learn more](<https://en.wikipedia.org/wiki/Shared_web_hosting_service> "Wikipedia: Shared web hosting service")
 """

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1142,3 +1142,9 @@ Responding to interactions:
 
 *The initial response has to happen within 3s of receiving the interaction!*
 """
+
+[shared-hosting]
+keywords = ["shared-hosting", "replit"]
+content = """
+Replit and many other shared hosting services are highly discouraged; using such hosts means you will share the same IP with many other projects that send a large number of API requests. That means your bot is very likely to have its IP address banned and/or rate limited. [Learn more](https://en.wikipedia.org/wiki/Shared_web_hosting_service)
+"""


### PR DESCRIPTION
PR adds a tag for shared hosting providers like replit, their consequences and how to avoid them.

#### Tag:
<code>Replit and many other shared hosting services are highly discouraged; using such hosts means you will share the same IP with many other projects that send a large number of API requests. That means your bot is very likely to have its IP address banned and/or rate limited. To avoid this you should use a hosting provider that is not shared, check out <#729580210634358804> for affordable options. [Learn more](<https://en.wikipedia.org/wiki/Shared_web_hosting_service> "Wikipedia: Shared web hosting service")
</code>
(Wrapped in an inline codeblock here since markdown doesn't support codeblock wrapping)