### PR TITLE
chore: use base options in docs command

### DIFF
--- a/src/interactions/docs.ts
+++ b/src/interactions/docs.ts
@@ -21,7 +21,7 @@ const BASE_OPTIONS = [
 		description: 'Hide command output',
 		required: false,
 	},
-]
+] as const;
 
 export const DocsCommand = {
 	name: 'docs',

--- a/src/interactions/docs.ts
+++ b/src/interactions/docs.ts
@@ -1,9 +1,27 @@
 import { ApplicationCommandOptionType } from 'discord-api-types/v10';
 
-const QUERY_DESCRIPTION = 'Class or Class#method combination to search for' as const;
-const TARGET_DESCRIPTION = 'User to mention' as const;
 const SUBCOMMAND_DESCRIPTION_PREFIX = 'Display docs for' as const;
-const EPHEMERAL_DESCRIPTION = 'Hide command output' as const;
+const BASE_OPTIONS = [
+	{
+		type: ApplicationCommandOptionType.String,
+		name: 'query',
+		description: 'Class or Class#method combination to search for',
+		required: true,
+		autocomplete: true,
+	},
+	{
+		type: ApplicationCommandOptionType.User,
+		name: 'target',
+		description: 'User to mention',
+		required: false,
+	},
+	{
+		type: ApplicationCommandOptionType.Boolean,
+		name: 'hide',
+		description: 'Hide command output',
+		required: false,
+	},
+]
 
 export const DocsCommand = {
 	name: 'docs',
@@ -13,151 +31,37 @@ export const DocsCommand = {
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'discord-js-v13',
 			description: `${SUBCOMMAND_DESCRIPTION_PREFIX} discord.js@v13-lts`,
-			options: [
-				{
-					type: ApplicationCommandOptionType.String,
-					name: 'query',
-					description: QUERY_DESCRIPTION,
-					required: true,
-					autocomplete: true,
-				},
-				{
-					type: ApplicationCommandOptionType.User,
-					name: 'target',
-					description: TARGET_DESCRIPTION,
-					required: false,
-				},
-				{
-					type: ApplicationCommandOptionType.Boolean,
-					name: 'hide',
-					description: EPHEMERAL_DESCRIPTION,
-					required: false,
-				},
-			],
+			options: BASE_OPTIONS,
 		},
 		{
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'discord-js-v14',
 			description: `${SUBCOMMAND_DESCRIPTION_PREFIX} discord.js@latest`,
-			options: [
-				{
-					type: ApplicationCommandOptionType.String,
-					name: 'query',
-					description: QUERY_DESCRIPTION,
-					required: true,
-					autocomplete: true,
-				},
-				{
-					type: ApplicationCommandOptionType.User,
-					name: 'target',
-					description: TARGET_DESCRIPTION,
-					required: false,
-				},
-				{
-					type: ApplicationCommandOptionType.Boolean,
-					name: 'hide',
-					description: EPHEMERAL_DESCRIPTION,
-					required: false,
-				},
-			],
+			options: BASE_OPTIONS,
 		},
 		{
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'discord-js-dev',
 			description: `${SUBCOMMAND_DESCRIPTION_PREFIX} discord.js@dev`,
-			options: [
-				{
-					type: ApplicationCommandOptionType.String,
-					name: 'query',
-					description: QUERY_DESCRIPTION,
-					required: true,
-					autocomplete: true,
-				},
-				{
-					type: ApplicationCommandOptionType.User,
-					name: 'target',
-					description: TARGET_DESCRIPTION,
-					required: false,
-				},
-			],
+			options: BASE_OPTIONS,
 		},
 		{
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'collection',
 			description: `${SUBCOMMAND_DESCRIPTION_PREFIX} @discordjs/collection`,
-			options: [
-				{
-					type: ApplicationCommandOptionType.String,
-					name: 'query',
-					description: QUERY_DESCRIPTION,
-					required: true,
-					autocomplete: true,
-				},
-				{
-					type: ApplicationCommandOptionType.User,
-					name: 'target',
-					description: TARGET_DESCRIPTION,
-					required: false,
-				},
-				{
-					type: ApplicationCommandOptionType.Boolean,
-					name: 'hide',
-					description: EPHEMERAL_DESCRIPTION,
-					required: false,
-				},
-			],
+			options: BASE_OPTIONS,
 		},
 		{
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'voice',
 			description: `${SUBCOMMAND_DESCRIPTION_PREFIX} @discordjs/voice`,
-			options: [
-				{
-					type: ApplicationCommandOptionType.String,
-					name: 'query',
-					description: QUERY_DESCRIPTION,
-					required: true,
-					autocomplete: true,
-				},
-				{
-					type: ApplicationCommandOptionType.User,
-					name: 'target',
-					description: TARGET_DESCRIPTION,
-					required: false,
-				},
-				{
-					type: ApplicationCommandOptionType.Boolean,
-					name: 'hide',
-					description: EPHEMERAL_DESCRIPTION,
-					required: false,
-				},
-			],
+			options: BASE_OPTIONS,
 		},
 		{
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'builders',
 			description: `${SUBCOMMAND_DESCRIPTION_PREFIX} @discordjs/builders`,
-			options: [
-				{
-					type: ApplicationCommandOptionType.String,
-					name: 'query',
-					description: QUERY_DESCRIPTION,
-					required: true,
-					autocomplete: true,
-				},
-				{
-					type: ApplicationCommandOptionType.User,
-					name: 'target',
-					description: TARGET_DESCRIPTION,
-					required: false,
-				},
-				{
-					type: ApplicationCommandOptionType.Boolean,
-					name: 'hide',
-					description: EPHEMERAL_DESCRIPTION,
-					required: false,
-				},
-			],
+			options: BASE_OPTIONS,
 		},
 	],
 } as const;


### PR DESCRIPTION
Simplifies the whole file, because every subcommand had the same options

Adds missing hide option to `discord-js-dev`