### PR TITLE
chore (tags): Update "matching parameters" tag

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -447,8 +447,8 @@ The order of function parameters must match between definition and function call
 function execute(client, interaction) { ... };
 execute(interaction, client);
 ```
-• mismatch! you pass an Interaction where the Client is expected
-• mismatch! you pass the Client where an Interaction is expected
+• mismatch! you pass an interaction where the client is expected
+• mismatch! you pass the client where an interaction is expected
 """
 
 [mass-dm]

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -444,11 +444,11 @@ keywords = ["matching-parameters", "params", "matching-params", "parameters"]
 content = """
 The order of function parameters must match between definition and function call.
 ```js
-function execute(client, message, args) { ... };
-execute(message, client, args);
+function execute(client, interaction) { ... };
+execute(interaction, client);
 ```
-• mismatch! you pass a Message where the client is expected
-• mismatch! you pass the Client where a Message is expected
+• mismatch! you pass an Interaction where the Client is expected
+• mismatch! you pass the Client where an Interaction is expected
 """
 
 [mass-dm]


### PR DESCRIPTION
Change the tag to use `Interaction` instead of `Message`, as the general use case has changed since the tag was first written.