### PR TITLE
chore(tags): update required nodejs version

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -170,7 +170,7 @@ const channel = guild.channels.cache.find(channel => channel.name === "general")
 [node-version]
 keywords = ["nv", "flat", "fields-flat", "catch-{", "update-node", "abortcontroller"]
 content = """
-Please update Node.js to version 16.9.0 or newer!
+Please update Node.js to version 16.11.0 or newer!
 - [Download](https://nodejs.org/en/download)
 - [Linux (nodesource)](https://github.com/nodesource/distributions)
 """


### PR DESCRIPTION
Updates the required nodejs version to 16.11.0, since the latest release v14.12.1 requires it when using typescript