### PR TITLE
refactor(abort): update timeout to v14 equivalent

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -799,7 +799,7 @@ Ratelimits are dynamically assigned by the API based on current load and may cha
 keywords = ["abort-error"]
 content = """
 `AbortError: The user aborted a request.`
-A request took longer than the specified [timeout](https://discordjs.dev/docs/packages/rest/2.0.1/RESTOptions:Interface#timeout) (15 seconds default), and was aborted to not lock up the request handler.
+A request took longer than the specified [timeout](https://discordjs.dev/docs/packages/rest/stable/RESTOptions:Interface#timeout) (15 seconds default), and was aborted to not lock up the request handler.
 - This can be caused by an internal server error on Discord's side, or just a slow connection.
 - In case of a slow connection, the `timeout` option in [RESTOptions](https://discordjs.dev/docs/packages/rest/2.0.1/RESTOptions:Interface#timeout) can be increased to prevent future AbortErrors.
 """

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -799,9 +799,9 @@ Ratelimits are dynamically assigned by the API based on current load and may cha
 keywords = ["abort-error"]
 content = """
 `AbortError: The user aborted a request.`
-A request took longer than the specified [restRequestTimeout](https://old.discordjs.dev/#/docs/discord.js/14.13.0/typedef/ClientOptions) (15 seconds default), and was aborted to not lock up the request handler.
+A request took longer than the specified [timeout](https://discordjs.dev/docs/packages/rest/2.0.1/RESTOptions:Interface#timeout) (15 seconds default), and was aborted to not lock up the request handler.
 - This can be caused by an internal server error on Discord's side, or just a slow connection.
-- In case of a slow connection, the `restRequestTimeout` option in [ClientOptions](https://old.discordjs.dev/#/docs/discord.js/14.13.0/typedef/ClientOptions) can be increased to prevent future AbortErrors.
+- In case of a slow connection, the `timeout` option in [RESTOptions](https://discordjs.dev/docs/packages/rest/2.0.1/RESTOptions:Interface#timeout) can be increased to prevent future AbortErrors.
 """
 
 [v14-changes]

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -801,7 +801,7 @@ content = """
 `AbortError: The user aborted a request.`
 A request took longer than the specified [timeout](https://discordjs.dev/docs/packages/rest/stable/RESTOptions:Interface#timeout) (15 seconds default), and was aborted to not lock up the request handler.
 - This can be caused by an internal server error on Discord's side, or just a slow connection.
-- In case of a slow connection, the `timeout` option in [RESTOptions](https://discordjs.dev/docs/packages/rest/2.0.1/RESTOptions:Interface#timeout) can be increased to prevent future AbortErrors.
+- In case of a slow connection, the `timeout` option in [RESTOptions](https://discordjs.dev/docs/packages/rest/stable/RESTOptions:Interface#timeout) can be increased to prevent future AbortErrors.
 """
 
 [v14-changes]


### PR DESCRIPTION
`ClientOptions.restRequestTimeout` was changed to `RESTOptions.timeout` in v14 as we now use /rest.

I'm considering adding that this can be added to `ClientOptions` through `{ rest: { timeout: ... } }` too, not sure.