### PR TITLE
feat: Update Node.js version to LTS

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -220,7 +220,7 @@ keywords = [
     "abortcontroller",
 ]
 content = """
-Please update Node.js to the LTS version!
+Please update Node.js to the [current LTS](https://nodejs.org/) (long-term support) version!
 - [Download](https://nodejs.org/en/download)
 - [Linux (nodesource)](https://github.com/nodesource/distributions)
 """

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -220,7 +220,7 @@ keywords = [
     "abortcontroller",
 ]
 content = """
-Please update Node.js to version 16.11.0 or newer!
+Please update Node.js to the LTS version!
 - [Download](https://nodejs.org/en/download)
 - [Linux (nodesource)](https://github.com/nodesource/distributions)
 """


### PR DESCRIPTION
If this tag is given to someone, it's because they're using an outdated Node.js version. Instead of telling them to update to a specific version which involves updating this tag as time goes by, we should instruct them to use the LTS version which will be enough for discord.js.