### PR TITLE
Ephemeral tag

### DIFF
--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1224,6 +1224,6 @@ The `ephemeral` option will be removed
 [entry-point] 
 keywords = ["50240", "remove-entry-point"]
 content = """ 
-You have enabled activities in the Activity Settings on the dev portal.
-Either do not emable it if you dont need it or include the command that was created in the request body
+You have enabled activities in the Activity Settings on the Developer Portal.
+Either do not enable them if you do not need them, or include the command that was created in the request body.
 """

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1214,7 +1214,7 @@ While there might be a way for these features to work, it can change at any time
 [ephemeral] 
 keywords = ["ephemeral-deprecated"]
 content = """ 
-The `ephemeral` option will be removed
+The `ephemeral` option when replying to an interaction will be removed in v15
 ```diff
 - {..., ephemeral: true}
 + {..., flags: MessageFlags.Ephemeral}

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1211,10 +1211,20 @@ discord.js does not support features until they are officially documented.
 While there might be a way for these features to work, it can change at any time without any notice 
 """
 
-[partial-group-dm]
-keywords = ["group-dm", "send-does-not-exist"]
+
+[ephemeral] 
+keywords = ["ephemeral-deprecated"]
 content = """ 
-Bots cannot send messages in partial group dm channels.
-Use `if ('send' in channel)` or compare `channel.type` to mitigate this.
-A fix will be implemented in 14.16.2, where you can use `channel.isSendable()`
+The `ephemeral` option will be removed
+```diff
+- {..., ephemeral: true}
++ {..., flags: MessageFlags.Ephemeral}
+``` Read [here](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR>) on how to specify multiple flags
+"""
+
+[entry-point] 
+keywords = ["50240", "remove-entry-point"]
+content = """ 
+You have enabled activities in the Activity Settings on the dev portal.
+Either do not emable it if you dont need it or include the command that was created in the request body
 """

--- a/tags/tags.toml
+++ b/tags/tags.toml
@@ -1211,7 +1211,6 @@ discord.js does not support features until they are officially documented.
 While there might be a way for these features to work, it can change at any time without any notice 
 """
 
-
 [ephemeral] 
 keywords = ["ephemeral-deprecated"]
 content = """ 


### PR DESCRIPTION
new tag added for the deprecation warning of ephemeral in 14.17, as well as for the 50240 (You cannot remove this app's Entry Point command ...) error.
Removed the partial-group-dm tag as this was resolved in 14.16.2