### PR TITLE
ci: Update miscellaneous workflow code

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,13 +8,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install node20 runtime
+      - name: Install node22 runtime
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
-        run: rm -rf node_modules && yarn install --frozen-lockfile
+        run: rm -rf node_modules && yarn install
 
       - name: Run ESLint
         run: yarn lint

--- a/.github/workflows/validateWithLinks.yml
+++ b/.github/workflows/validateWithLinks.yml
@@ -9,13 +9,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install node20 runtime
+      - name: Install node22 runtime
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
-        run: rm -rf node_modules && yarn install --frozen-lockfile
+        run: rm -rf node_modules && yarn install
 
       - name: Run ESLint
         run: yarn lint


### PR DESCRIPTION
- Using Node.js22
- `--frozen-lockfile` is a legacy flag that will be removed in the future (`--immutable` is the standard). Anyway, this is not needed as in CI environments, [`--immutable` is the default](https://yarnpkg.com/cli/install)